### PR TITLE
Adding a Matrix chat to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ known, up-to-date methods for getting things to work.
 Outside the proton thread, additional credit goes to @akp for the initial revision
 of the Opentrack instructions, and @bradley-r for the Linuxtrack, Scratchpad and V4L2 info.
 
+To chat about DCS World on Linux there is a Matrix chat available:
+* https://matrix.to/#/#dcs-on-linux:matrix.org
+
 ## Contents
 
    * [Installation](#installation)


### PR DESCRIPTION
This adds links to the chatroom #dcs-on-linux on Hackint.org. Thought it might be nice to have to share experiences with DCS World setup and usage on Linux?

---

Just created this room (and am quite new to DCS on Linux myself), thought it might be helpful for people who want to get started with DCS on Linux? And it's just a suggestion, but I thought people on Linux might prefer IRC/Matrix over Discord, for example.  I'd also be happy to give other people privileges to the channel (and in fact would be happy handover and remove mine).

If something like this already exists then let me know and other than that please ignore :-).